### PR TITLE
Added missing dependency to webpack-dev-middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript": "^1.8.9",
     "typings": "^0.7.11",
     "webpack": "^1.12.14",
+    "webpack-dev-middleware": "^1.6.1",
     "webpack-dev-server": "^1.14.1",
     "webpack-hot-middleware": "^2.10.0"
   },


### PR DESCRIPTION
`npm run dev` fails unless webpack-dev-middleware is also installed. I simply added it to the package.json so it gets installed with everything else on `npm install`
